### PR TITLE
Consider to add more extensions to the ITimer interface

### DIFF
--- a/Vostok.Metrics.Tests/Primitives/Timer/ITimerExtensions_Measurement_Tests.cs
+++ b/Vostok.Metrics.Tests/Primitives/Timer/ITimerExtensions_Measurement_Tests.cs
@@ -68,7 +68,7 @@ namespace Vostok.Metrics.Tests.Primitives.Timer
                 Thread.Sleep(0.01.Seconds());
             }
 
-            @event.Value.Should().BeGreaterThan(0.01);
+            @event.Value.Should().BeGreaterThan(0.001);
         }
 
         [Test]
@@ -79,7 +79,7 @@ namespace Vostok.Metrics.Tests.Primitives.Timer
             var timer = context.CreateTimer("name");
 
             timer.MeasureSync(() => Thread.Sleep(0.01.Seconds()));
-            @event.Value.Should().BeGreaterThan(0.01);
+            @event.Value.Should().BeGreaterThan(0.001);
         }
 
         [Test]
@@ -96,7 +96,7 @@ namespace Vostok.Metrics.Tests.Primitives.Timer
                 })
                 .Should()
                 .Be(42);
-            @event.Value.Should().BeGreaterThan(0.01);
+            @event.Value.Should().BeGreaterThan(0.001);
         }
 
         [Test]
@@ -112,7 +112,7 @@ namespace Vostok.Metrics.Tests.Primitives.Timer
                 throw new Exception();
             });
             measurement.Should().Throw<Exception>();
-            @event.Value.Should().BeGreaterThan(0.01);
+            @event.Value.Should().BeGreaterThan(0.001);
         }
 
         [Test]
@@ -128,7 +128,7 @@ namespace Vostok.Metrics.Tests.Primitives.Timer
                 throw new Exception();
             });
             measurement.Should().Throw<Exception>();
-            @event.Value.Should().BeGreaterThan(0.01);
+            @event.Value.Should().BeGreaterThan(0.001);
         }
 
         [Test]
@@ -139,7 +139,7 @@ namespace Vostok.Metrics.Tests.Primitives.Timer
             var timer = context.CreateTimer("name");
 
             await timer.MeasureAsync(async () => await Task.Delay(0.01.Seconds()));
-            @event.Value.Should().BeGreaterThan(0.01);
+            @event.Value.Should().BeGreaterThan(0.001);
         }
 
         [Test]
@@ -156,7 +156,7 @@ namespace Vostok.Metrics.Tests.Primitives.Timer
                 }))
                 .Should()
                 .Be(42);
-            @event.Value.Should().BeGreaterThan(0.01);
+            @event.Value.Should().BeGreaterThan(0.001);
         }
     }
 }

--- a/Vostok.Metrics.Tests/Primitives/Timer/ITimerExtensions_Measurement_Tests.cs
+++ b/Vostok.Metrics.Tests/Primitives/Timer/ITimerExtensions_Measurement_Tests.cs
@@ -65,10 +65,10 @@ namespace Vostok.Metrics.Tests.Primitives.Timer
 
             using (timer.Measure())
             {
-                Thread.Sleep(0.1.Seconds());
+                Thread.Sleep(0.01.Seconds());
             }
 
-            @event.Value.Should().BeInRange(0.1, 0.2);
+            @event.Value.Should().BeGreaterThan(0.01);
         }
 
         [Test]
@@ -78,8 +78,8 @@ namespace Vostok.Metrics.Tests.Primitives.Timer
             var context = new MetricContext(new MetricContextConfig(new AdHocMetricEventSender(e => @event = e)));
             var timer = context.CreateTimer("name");
 
-            timer.MeasureSync(() => Thread.Sleep(0.1.Seconds()));
-            @event.Value.Should().BeInRange(0.1, 0.2);
+            timer.MeasureSync(() => Thread.Sleep(0.01.Seconds()));
+            @event.Value.Should().BeGreaterThan(0.01);
         }
 
         [Test]
@@ -91,12 +91,12 @@ namespace Vostok.Metrics.Tests.Primitives.Timer
 
             timer.MeasureSync(() =>
                 {
-                    Thread.Sleep(0.1.Seconds());
+                    Thread.Sleep(0.01.Seconds());
                     return 42;
                 })
                 .Should()
                 .Be(42);
-            @event.Value.Should().BeInRange(0.1, 0.2);
+            @event.Value.Should().BeGreaterThan(0.01);
         }
 
         [Test]
@@ -108,11 +108,11 @@ namespace Vostok.Metrics.Tests.Primitives.Timer
 
             Action measurement = () => timer.MeasureSync(() =>
             {
-                Thread.Sleep(0.1.Seconds());
+                Thread.Sleep(0.01.Seconds());
                 throw new Exception();
             });
             measurement.Should().Throw<Exception>();
-            @event.Value.Should().BeInRange(0.1, 0.2);
+            @event.Value.Should().BeGreaterThan(0.01);
         }
 
         [Test]
@@ -124,11 +124,11 @@ namespace Vostok.Metrics.Tests.Primitives.Timer
 
             Func<Task> measurement = () => timer.MeasureAsync(async () =>
             {
-                await Task.Delay(0.1.Seconds());
+                await Task.Delay(0.01.Seconds());
                 throw new Exception();
             });
             measurement.Should().Throw<Exception>();
-            @event.Value.Should().BeInRange(0.1, 0.2);
+            @event.Value.Should().BeGreaterThan(0.01);
         }
 
         [Test]
@@ -138,8 +138,8 @@ namespace Vostok.Metrics.Tests.Primitives.Timer
             var context = new MetricContext(new MetricContextConfig(new AdHocMetricEventSender(e => @event = e)));
             var timer = context.CreateTimer("name");
 
-            await timer.MeasureAsync(async () => await Task.Delay(0.1.Seconds()));
-            @event.Value.Should().BeInRange(0.1, 0.2);
+            await timer.MeasureAsync(async () => await Task.Delay(0.01.Seconds()));
+            @event.Value.Should().BeGreaterThan(0.01);
         }
 
         [Test]
@@ -151,12 +151,12 @@ namespace Vostok.Metrics.Tests.Primitives.Timer
 
             (await timer.MeasureAsync(async () =>
                 {
-                    await Task.Delay(0.1.Seconds());
+                    await Task.Delay(0.01.Seconds());
                     return 42;
                 }))
                 .Should()
                 .Be(42);
-            @event.Value.Should().BeInRange(0.1, 0.2);
+            @event.Value.Should().BeGreaterThan(0.01);
         }
     }
 }

--- a/Vostok.Metrics.Tests/Primitives/Timer/ITimerExtensions_Measurement_Tests.cs
+++ b/Vostok.Metrics.Tests/Primitives/Timer/ITimerExtensions_Measurement_Tests.cs
@@ -80,7 +80,8 @@ namespace Vostok.Metrics.Tests.Primitives.Timer
             var timer = context.CreateTimer("name");
 
             timer.Measure(() => Thread.Sleep(0.1.Seconds()));
-            @event.Value.Should().BeApproximately(0.1, precision: 0.01);
+            @event.Value.Should().BeGreaterThan(0.1);
+            @event.Value.Should().BeLessThan(0.2);
         }
 
         [Test]
@@ -97,7 +98,8 @@ namespace Vostok.Metrics.Tests.Primitives.Timer
                 })
                 .Should()
                 .Be(42);
-            @event.Value.Should().BeApproximately(0.1, precision: 0.01);
+            @event.Value.Should().BeGreaterThan(0.1);
+            @event.Value.Should().BeLessThan(0.2);
         }
 
         [Test]
@@ -112,7 +114,8 @@ namespace Vostok.Metrics.Tests.Primitives.Timer
                 Thread.Sleep(0.1.Seconds());
                 throw new Exception();
             });
-            @event.Value.Should().BeApproximately(0.1, precision: 0.01);
+            @event.Value.Should().BeGreaterThan(0.1);
+            @event.Value.Should().BeLessThan(0.2);
         }
 
         [Test]
@@ -123,7 +126,8 @@ namespace Vostok.Metrics.Tests.Primitives.Timer
             var timer = context.CreateTimer("name");
 
             await timer.Measure(async () => await Task.Delay(0.1.Seconds()));
-            @event.Value.Should().BeApproximately(0.1, precision: 0.01);    
+            @event.Value.Should().BeGreaterThan(0.1);
+            @event.Value.Should().BeLessThan(0.2);
         }
     }
 }

--- a/Vostok.Metrics/Primitives/Timer/ITimerExtensions_Measurement.cs
+++ b/Vostok.Metrics/Primitives/Timer/ITimerExtensions_Measurement.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 
 namespace Vostok.Metrics.Primitives.Timer
@@ -13,6 +14,58 @@ namespace Vostok.Metrics.Primitives.Timer
 
         public static IDisposable Measure([NotNull] this ITimer timer)
             => new Measurement(timer);
+
+        public static T Measure<T>([NotNull] this ITimer timer, Func<T> action)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            try
+            {
+                return action();
+            }
+            finally
+            {
+                timer.Report(stopwatch.Elapsed);
+            }
+        }
+
+        public static void Measure([NotNull] this ITimer timer, Action action)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            try
+            {
+                action();
+            }
+            finally
+            {
+                timer.Report(stopwatch.Elapsed);
+            }
+        }
+
+        public static async Task<T> Measure<T>([NotNull] this ITimer timer, Func<Task<T>> action)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            try
+            {
+                return await action().ConfigureAwait(false);
+            }
+            finally
+            {
+                timer.Report(stopwatch.Elapsed);
+            }
+        }
+
+        public static async Task Measure([NotNull] this ITimer timer, Func<Task> action)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            try
+            {
+                await action().ConfigureAwait(false);
+            }
+            finally
+            {
+                timer.Report(stopwatch.Elapsed);
+            }
+        }
 
         private class Measurement : Stopwatch, IDisposable
         {

--- a/Vostok.Metrics/Primitives/Timer/ITimerExtensions_Measurement.cs
+++ b/Vostok.Metrics/Primitives/Timer/ITimerExtensions_Measurement.cs
@@ -15,56 +15,28 @@ namespace Vostok.Metrics.Primitives.Timer
         public static IDisposable Measure([NotNull] this ITimer timer)
             => new Measurement(timer);
 
-        public static T Measure<T>([NotNull] this ITimer timer, Func<T> action)
+        public static T MeasureSync<T>([NotNull] this ITimer timer, [NotNull] Func<T> func)
         {
-            var stopwatch = Stopwatch.StartNew();
-            try
-            {
-                return action();
-            }
-            finally
-            {
-                timer.Report(stopwatch.Elapsed);
-            }
+            using (timer.Measure())
+                return func();
         }
 
-        public static void Measure([NotNull] this ITimer timer, Action action)
+        public static void MeasureSync([NotNull] this ITimer timer, [NotNull] Action action)
         {
-            var stopwatch = Stopwatch.StartNew();
-            try
-            {
+            using (timer.Measure())
                 action();
-            }
-            finally
-            {
-                timer.Report(stopwatch.Elapsed);
-            }
         }
 
-        public static async Task<T> Measure<T>([NotNull] this ITimer timer, Func<Task<T>> action)
+        public static async Task<T> MeasureAsync<T>([NotNull] this ITimer timer, [NotNull] Func<Task<T>> func)
         {
-            var stopwatch = Stopwatch.StartNew();
-            try
-            {
-                return await action().ConfigureAwait(false);
-            }
-            finally
-            {
-                timer.Report(stopwatch.Elapsed);
-            }
+            using (timer.Measure())
+                return await func().ConfigureAwait(false);
         }
 
-        public static async Task Measure([NotNull] this ITimer timer, Func<Task> action)
+        public static async Task MeasureAsync([NotNull] this ITimer timer, [NotNull] Func<Task> action)
         {
-            var stopwatch = Stopwatch.StartNew();
-            try
-            {
+            using (timer.Measure())
                 await action().ConfigureAwait(false);
-            }
-            finally
-            {
-                timer.Report(stopwatch.Elapsed);
-            }
         }
 
         private class Measurement : Stopwatch, IDisposable


### PR DESCRIPTION
Popular metrics libraries (like App.Metrics) provides a bunch of extensions to simplify metrics reporting. Usually, there are two basic methods: one that returns `IDisposable` that report metric at the `Dispose` call and the other that allows the user to measure the duration of lambda from the arguments (https://www.app-metrics.io/getting-started/metric-types/timers/).

A brief investigation of `vostok.metrics` library capabilities don't show any possible alternatives to the extension of `ITimer` that simplifies the duration measurement of lambda expressions. Of course, I can surround expression with using block but in the case when the return value is used in another part of the function body I need to extract some temporary variables in the outer scope and this makes code messier.

This PR extends `ITimer` with a bunch of extensions that simplify the measurement of the duration of lambdas. I choose to overload the `Measure(...)` function signature for the sake of API simplicity. I also add overloads for async operations but maybe this is a bad choice for a generic purpose library (for some reason App.Metrics and Metrics.NET don't have such overloads). Async overloads don't have `...Async` suffix in the function name because in this case the user of the library can misspell function call and get wrong measurements (in the case when sync version of the method was called).